### PR TITLE
Add support for URLRequest, delegates and URL

### DIFF
--- a/Sources/Packet/URL+Chunks.swift
+++ b/Sources/Packet/URL+Chunks.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension URL {
+    /// The URL's resource data, as an asynchronous sequence of ``Data`` chunks
+    ///
+    /// Use this property with Swift's `for-await-in` syntax to read the contents of a URL in chunks like this:
+    /// ```swift
+    /// guard let url = URL(string: "https://www.example.com") else {
+    ///     return
+    /// }
+    ///
+    /// do {
+    ///     // Read each chunk of the data as it becomes available
+    ///     for try await chunk in url.resourceChunks {
+    ///         // Do something with chunk
+    ///     }
+    /// } catch {
+    ///     print("Error: \(error)")
+    /// }
+    @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+    public var resourceChunks: AsyncThrowingDataChunks {
+        return URLSession.shared.chunks(for: self)
+    }
+}

--- a/Sources/Packet/URLSession+Chunks.swift
+++ b/Sources/Packet/URLSession+Chunks.swift
@@ -1,19 +1,36 @@
 import Foundation
 
-public typealias AsyncThrowingDataChunks = AsyncThrowingStream<Data, Error>
+public typealias AsyncThrowingDataChunks = AsyncThrowingStream<Data, any Error>
 
 extension URLSession {
     /// Retrieves the contents of a url and delivers the data asynchronously as `Data` chunks.
     /// - Parameter url: The URL to retrieve.
+    /// - Parameter delegate: A delegate that receives life cycle and authentication challenge callbacks as the transfer progresses.
     /// - Returns: An asychronously-delivered ``AsyncThrowingDataChunks`` sequence to iterate over.
     ///
     /// Use this method to when you want to process the chunks while the transfer is underway. You can use
-    /// a `for-try-await-in` loop to handle each chunk.
+    /// a `for-await-in` loop to handle each chunk like this:
+    /// ```swift
+    /// guard let url = URL(string: "https://www.example.com") else {
+    ///     return
+    /// }
+    ///
+    /// do {
+    ///     // Read each chunk of the data as it becomes available
+    ///     for try await chunk in URLSession.chunks(for: url) {
+    ///         // Do something with chunk
+    ///     }
+    /// } catch {
+    ///     print("Error \(error)")
+    /// }
+    /// ```
     @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-    public func chunks(for url: URL) -> AsyncThrowingDataChunks {
+    public func chunks(for url: URL, 
+                       delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
         AsyncThrowingDataChunks { continuation in
             let dataTask = dataTask(with: url)
-            dataTask.delegate = DataChunksTaskDelegate(withContinuation: continuation)
+            dataTask.delegate = DataChunksTaskDelegate(withContinuation: continuation, delegate: delegate)
+            
             
             dataTask.resume()
         }
@@ -22,9 +39,12 @@ extension URLSession {
 
 private final class DataChunksTaskDelegate: NSObject {
     let continuation: AsyncThrowingDataChunks.Continuation
+    let delegate: (any URLSessionTaskDelegate)?
     
-    init(withContinuation continuation: AsyncThrowingDataChunks.Continuation) {
+    init(withContinuation continuation: AsyncThrowingDataChunks.Continuation,
+         delegate: (any URLSessionTaskDelegate)?) {
         self.continuation = continuation
+        self.delegate = delegate
     }
 }
 
@@ -43,5 +63,25 @@ extension DataChunksTaskDelegate: URLSessionDataDelegate {
         } else {
             continuation.finish()
         }
+    }
+    
+    public func urlSession(_ session: URLSession, 
+                           task: URLSessionTask,
+                           willPerformHTTPRedirection response: HTTPURLResponse,
+                           newRequest request: URLRequest,
+                           completionHandler: @escaping @Sendable (URLRequest?) -> Void) {
+        delegate?.urlSession?(session, task: task, willPerformHTTPRedirection: response, newRequest: request, completionHandler: completionHandler)
+    }
+    
+    public func urlSession(_ session: URLSession, 
+                           task: URLSessionTask,
+                           didReceive challenge: URLAuthenticationChallenge,
+                           completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        delegate?.urlSession?(session, task: task, didReceive: challenge, completionHandler: completionHandler)
+    }
+    
+    public func urlSession(_ session: URLSession, 
+                           taskIsWaitingForConnectivity task: URLSessionTask) {
+        delegate?.urlSession?(session, taskIsWaitingForConnectivity: task)
     }
 }

--- a/Sources/Packet/URLSession+Chunks.swift
+++ b/Sources/Packet/URLSession+Chunks.swift
@@ -27,10 +27,40 @@ extension URLSession {
     @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
     public func chunks(for url: URL, 
                        delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
+        return chunks(for: URLRequest(url: url), delegate: delegate)
+    }
+    
+    /// Retrieves the contents of a URL based on the specified URL request and delivers an asynchronous 
+    /// sequence of `Data` chunks.
+    /// - Parameter request: A URL request object that provides request-specific information
+    /// such as the URL, cache policy, request type, and body data or body stream.
+    /// - Parameter delegate: A delegate that receives life cycle and authentication challenge callbacks as the transfer progresses.
+    /// - Returns: An asynchronously delivered ``AsyncThrowingDataChunks`` sequence to iterate over
+    ///
+    /// Use this method when you want to process the bytes while the transfer is underway. You can use
+    /// a `for-await-in` loop to handle each chunk like this:
+    /// ```swift
+    /// guard let url = URL(string: "https://www.example.com") else {
+    ///     return
+    /// }
+    ///
+    /// let request = URLRequest(url)
+    /// do {
+    ///     // Read each chunk of the data as it becomes available
+    ///     for try await chunk in URLSession.chunks(for: request) {
+    ///         // Do something with chunk
+    ///     }
+    /// } catch {
+    ///     print("Error: \(error)")
+    /// }
+    /// ```
+    @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func chunks(for request: URLRequest,
+                       delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
         AsyncThrowingDataChunks { continuation in
-            let dataTask = dataTask(with: url)
-            dataTask.delegate = DataChunksTaskDelegate(withContinuation: continuation, delegate: delegate)
-            
+            let dataTask = dataTask(with: request)
+            dataTask.delegate = DataChunksTaskDelegate(withContinuation: continuation,
+                                                       delegate: delegate)
             
             dataTask.resume()
         }

--- a/Tests/PacketTests/URLSessionTests.swift
+++ b/Tests/PacketTests/URLSessionTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class URLSessionTests: XCTestCase {
     @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, tvOS 16.0, watchOS 9.0, *)
-    func testChunks() async throws {
+    func testURL() async throws {
         let testURL = Bundle.module.url(forResource: "ipsum100k", withExtension: "txt")
         XCTAssertNotNil(testURL, "Unable to find test file")
         
@@ -12,6 +12,24 @@ final class URLSessionTests: XCTestCase {
         
         var byteCount = 0
         let chunkStream = URLSession.shared.chunks(for: testURL!)
+        for try await data in chunkStream {
+            byteCount += data.count
+        }
+        
+        XCTAssert(byteCount == fileSize)
+    }
+    
+    @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, tvOS 16.0, watchOS 9.0, *)
+    func testURLRequest() async throws {
+        let testURL = Bundle.module.url(forResource: "ipsum100k", withExtension: "txt")
+        XCTAssertNotNil(testURL, "Unable to find test file")
+        
+        let attrs = try FileManager.default.attributesOfItem(atPath: testURL!.path(percentEncoded: false))
+        let fileSize = attrs[.size] as? UInt64 ?? UInt64(0)
+        
+        var byteCount = 0
+        let request = URLRequest(url: testURL!)
+        let chunkStream = URLSession.shared.chunks(for: request)
         for try await data in chunkStream {
             byteCount += data.count
         }

--- a/Tests/PacketTests/URLTest.swift
+++ b/Tests/PacketTests/URLTest.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Packet
+
+final class URLTests: XCTestCase {
+    @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, tvOS 16.0, watchOS 9.0, *)
+    func testURL() async throws {
+        let testURL = Bundle.module.url(forResource: "ipsum100k", withExtension: "txt")
+        XCTAssertNotNil(testURL, "Unable to find test file")
+        
+        let attrs = try FileManager.default.attributesOfItem(atPath: testURL!.path(percentEncoded: false))
+        let fileSize = attrs[.size] as? UInt64 ?? UInt64(0)
+        
+        var byteCount = 0
+        let chunkStream = testURL!.resourceChunks
+        for try await data in chunkStream {
+            byteCount += data.count
+        }
+        
+        XCTAssert(byteCount == fileSize)
+    }
+}


### PR DESCRIPTION
# Delegate support: 
Accept a delegate so the `chunks(for:delegate:)` method matches the official `bytes(for:delegate:)` method. If the user passes a delegate non-download related methods get passed to the user's delegate.

Some delegate methods aren't implemented because they didn't seem relevant and trying to chain the async version of `optional func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: https://github.com/escaping https://github.com/sendable (URLSession.AuthChallengeDisposition, URLCredential?)) -> Void` crashed the compiler, so it's not implemented either.

# URLRequest & URL

Support using a `URLRequest` on `URLSession.chunks(for:delegate:)` and `URL.resourceChunks`
