### PR TITLE
Return the URLResponse for chunks(for:delegate:)

### DIFF
--- a/Sources/Packet/URLSession+Chunks.swift
+++ b/Sources/Packet/URLSession+Chunks.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 public typealias AsyncThrowingDataChunks = AsyncThrowingStream<Data, any Error>
+typealias ResponseContinuation = CheckedContinuation<(AsyncThrowingDataChunks, URLResponse), Error>
 
 extension URLSession {
     /// Retrieves the contents of a url and delivers the data asynchronously as `Data` chunks.
     /// - Parameter url: The URL to retrieve.
     /// - Parameter delegate: A delegate that receives life cycle and authentication challenge callbacks as the transfer progresses.
-    /// - Returns: An asychronously-delivered ``AsyncThrowingDataChunks`` sequence to iterate over.
+    /// - Returns: An asychronously-delivered tuple containing an ``AsyncThrowingDataChunks`` sequence to iterate over
+    /// and the ``URLResponse`` from the server.
     ///
     /// Use this method to when you want to process the chunks while the transfer is underway. You can use
     /// a `for-await-in` loop to handle each chunk like this:
@@ -17,7 +19,8 @@ extension URLSession {
     ///
     /// do {
     ///     // Read each chunk of the data as it becomes available
-    ///     for try await chunk in URLSession.chunks(for: url) {
+    ///     let (chunks, response) = try await URLSession.shared.chunks(for: url)
+    ///     for try await chunk in chunks {
     ///         // Do something with chunk
     ///     }
     /// } catch {
@@ -25,17 +28,18 @@ extension URLSession {
     /// }
     /// ```
     @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
-    public func chunks(for url: URL, 
-                       delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
-        return chunks(for: URLRequest(url: url), delegate: delegate)
+    public func chunks(for url: URL,
+                       delegate: (any URLSessionTaskDelegate)? = nil) async throws -> (AsyncThrowingDataChunks, URLResponse) {
+        return try await chunks(for: URLRequest(url: url), delegate: delegate)
     }
     
-    /// Retrieves the contents of a URL based on the specified URL request and delivers an asynchronous 
+    /// Retrieves the contents of a URL based on the specified URL request and delivers an asynchronous
     /// sequence of `Data` chunks.
     /// - Parameter request: A URL request object that provides request-specific information
     /// such as the URL, cache policy, request type, and body data or body stream.
     /// - Parameter delegate: A delegate that receives life cycle and authentication challenge callbacks as the transfer progresses.
-    /// - Returns: An asynchronously delivered ``AsyncThrowingDataChunks`` sequence to iterate over
+    /// - Returns: An asynchronously delivered tuple of ``AsyncThrowingDataChunks`` sequence to iterate over
+    ///  and the ``URLResponse`` from the server.
     ///
     /// Use this method when you want to process the bytes while the transfer is underway. You can use
     /// a `for-await-in` loop to handle each chunk like this:
@@ -47,7 +51,8 @@ extension URLSession {
     /// let request = URLRequest(url)
     /// do {
     ///     // Read each chunk of the data as it becomes available
-    ///     for try await chunk in URLSession.chunks(for: request) {
+    ///     let (chunks, response) = try await URLSession.shared.chunks(for: request)
+    ///     for try await chunk in chunk {
     ///         // Do something with chunk
     ///     }
     /// } catch {
@@ -56,24 +61,62 @@ extension URLSession {
     /// ```
     @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
     public func chunks(for request: URLRequest,
-                       delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
+                       delegate: (any URLSessionTaskDelegate)? = nil) async throws -> (AsyncThrowingDataChunks, URLResponse) {
+        try await withCheckedThrowingContinuation { responseContinuation in
+            let chunksDelegate = DataChunksTaskDelegate(delegate: delegate)
+            chunksDelegate.responseContinuation = responseContinuation
+            
+            chunksDelegate.stream = AsyncThrowingDataChunks { streamContinuation in
+                chunksDelegate.continuation = streamContinuation
+                let dataTask = dataTask(with: request)
+                dataTask.delegate = chunksDelegate
+                dataTask.resume()
+            }
+        }
+    }
+    
+    @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+    func chunks(for url: URL,
+                delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
+        return chunks(for: URLRequest(url: url), delegate: delegate)
+    }
+    
+    @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+    func chunks(for request: URLRequest,
+                delegate: (any URLSessionTaskDelegate)? = nil) -> AsyncThrowingDataChunks {
         AsyncThrowingDataChunks { continuation in
             let dataTask = dataTask(with: request)
             dataTask.delegate = DataChunksTaskDelegate(withContinuation: continuation,
                                                        delegate: delegate)
-            
             dataTask.resume()
         }
     }
 }
 
 private final class DataChunksTaskDelegate: NSObject {
-    let continuation: AsyncThrowingDataChunks.Continuation
+    var continuation: AsyncThrowingDataChunks.Continuation?
     let delegate: (any URLSessionTaskDelegate)?
+    
+    var stream: AsyncThrowingDataChunks?
+    var responseContinuation: ResponseContinuation?
+    
+    init(delegate: (any URLSessionTaskDelegate)?) {
+        self.delegate = delegate
+    }
     
     init(withContinuation continuation: AsyncThrowingDataChunks.Continuation,
          delegate: (any URLSessionTaskDelegate)?) {
         self.continuation = continuation
+        self.delegate = delegate
+    }
+    
+    init(withContinuation continuation: AsyncThrowingDataChunks.Continuation,
+         responseContinuation: ResponseContinuation,
+         stream: AsyncThrowingDataChunks,
+         delegate: (any URLSessionTaskDelegate)?) {
+        self.continuation = continuation
+        self.responseContinuation = responseContinuation
+        self.stream = stream
         self.delegate = delegate
     }
 }
@@ -81,21 +124,35 @@ private final class DataChunksTaskDelegate: NSObject {
 extension DataChunksTaskDelegate: URLSessionDataDelegate {
     public func urlSession(_ session: URLSession,
                            dataTask: URLSessionDataTask,
+                           didReceive response: URLResponse,
+                           completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        
+        if let stream,
+           let responseContinuation {
+            responseContinuation.resume(returning: (stream, response))
+            self.responseContinuation = nil
+        }
+        completionHandler(.allow)
+    }
+    
+    public func urlSession(_ session: URLSession,
+                           dataTask: URLSessionDataTask,
                            didReceive data: Data) {
-        continuation.yield(data)
+        continuation?.yield(data)
     }
     
     public func urlSession(_ session: URLSession,
                            task: URLSessionTask,
                            didCompleteWithError error: Error?) {
         if let error {
-            continuation.finish(throwing: error)
+            responseContinuation?.resume(throwing: error)
+            continuation?.finish(throwing: error)
         } else {
-            continuation.finish()
+            continuation?.finish()
         }
     }
     
-    public func urlSession(_ session: URLSession, 
+    public func urlSession(_ session: URLSession,
                            task: URLSessionTask,
                            willPerformHTTPRedirection response: HTTPURLResponse,
                            newRequest request: URLRequest,
@@ -108,7 +165,7 @@ extension DataChunksTaskDelegate: URLSessionDataDelegate {
         }
     }
     
-    public func urlSession(_ session: URLSession, 
+    public func urlSession(_ session: URLSession,
                            task: URLSessionTask,
                            didReceive challenge: URLAuthenticationChallenge,
                            completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
@@ -120,7 +177,7 @@ extension DataChunksTaskDelegate: URLSessionDataDelegate {
         }
     }
     
-    public func urlSession(_ session: URLSession, 
+    public func urlSession(_ session: URLSession,
                            taskIsWaitingForConnectivity task: URLSessionTask) {
         delegate?.urlSession?(session, taskIsWaitingForConnectivity: task)
     }

--- a/Tests/PacketTests/URLSessionTests.swift
+++ b/Tests/PacketTests/URLSessionTests.swift
@@ -28,7 +28,8 @@ final class URLSessionTests: XCTestCase {
         let fileSize = attrs[.size] as? UInt64 ?? UInt64(0)
         
         var byteCount = 0
-        let chunkStream = URLSession.shared.chunks(for: testURL!)
+        let (chunkStream, _) = try await URLSession.shared.chunks(for: testURL!)
+        
         for try await data in chunkStream {
             byteCount += data.count
         }
@@ -46,7 +47,7 @@ final class URLSessionTests: XCTestCase {
         
         var byteCount = 0
         let request = URLRequest(url: testURL!)
-        let chunkStream = URLSession.shared.chunks(for: request)
+        let (chunkStream, _) = try await URLSession.shared.chunks(for: request)
         for try await data in chunkStream {
             byteCount += data.count
         }
@@ -59,7 +60,7 @@ final class URLSessionTests: XCTestCase {
         // Replace the session's URLResponder that fakes an authentication challenge
         // to make sure the delegate is handling it correctly
         let session = URLSession(mockResponder: SuccessfulResponder.self)
-        let chunkStream = session.chunks(for: URL(string:"\(MockSchemes.authenticate.rawValue)://fakefile")!)
+        let (chunkStream, _) = try await session.chunks(for: URL(string:"\(MockSchemes.authenticate.rawValue)://fakefile")!)
         for try await _ in chunkStream {
             // Don't really care about the chunk in this case, it's been tested
             // earlier, just testing that an authentication request doesn't fail
@@ -68,10 +69,10 @@ final class URLSessionTests: XCTestCase {
 
     @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, tvOS 16.0, watchOS 9.0, *)
     func testRedirectDelegate() async throws {
-        // Replace the session's URLResponder that fakes an authentication challenge
+        // Replace the session's URLResponder that fakes a redirect
         // to make sure the delegate is handling it correctly
         let session = URLSession(mockResponder: SuccessfulResponder.self)
-        let chunkStream = session.chunks(for: URL(string:"\(MockSchemes.redirect.rawValue)://fakefile")!)
+        let (chunkStream, _) = try await session.chunks(for: URL(string:"\(MockSchemes.redirect.rawValue)://fakefile")!)
         for try await _ in chunkStream {
             // Don't really care about the chunk in this case, it's been tested
             // earlier, just testing that an authentication request doesn't fail
@@ -87,10 +88,11 @@ final class URLSessionTests: XCTestCase {
     
     @available(iOS 16.0, macOS 13.0, macCatalyst 16.0, tvOS 16.0, watchOS 9.0, *)
     private func errorStream() async throws {
-        // Replace the session's URLResponder that fakes an authentication challenge
+        // Replace the session's URLResponder that fakes an error
         // to make sure the delegate is handling it correctly
         let session = URLSession(mockResponder: SuccessfulResponder.self)
-        let chunkStream = session.chunks(for: URL(string:"\(MockSchemes.error.rawValue)://fakefile")!)
+        let (chunkStream, _) = try await session.chunks(for: URL(string:"\(MockSchemes.error.rawValue)://fakefile")!)
+        
         for try await _ in chunkStream {
             // Don't really care about the chunk in this case, it's been tested
             // earlier, just testing that an authentication request doesn't fail

--- a/Tests/PacketTests/Utils/MockURLProtocol.swift
+++ b/Tests/PacketTests/Utils/MockURLProtocol.swift
@@ -67,15 +67,16 @@ class MockURLProtocol<Responder: MockURLResponder>: URLProtocol, URLAuthenticati
                                    wasRedirectedTo: newRequest,
                                    redirectResponse: response)
             }
-            
-            if scheme == MockSchemes.error.rawValue {
-                throw MockError.errorRequested
-            }
-            
+                        
             client.urlProtocol(self,
                                didReceive: response,
                                cacheStoragePolicy: .notAllowed
             )
+            
+            if scheme == MockSchemes.error.rawValue {
+                throw MockError.errorRequested
+            }
+
             client.urlProtocol(self, didLoad: data)
         } catch {
             client.urlProtocol(self, didFailWithError: error)


### PR DESCRIPTION
Change the `chunks(for:delegate:)` methods to return a tuple of `(AsyncThrowingDataChunks, URLResponse)` so it is a drop in replacement for `bytes(for:delegate:)`. This means it is now async.

I've left the original versions in but made them internal, so that the URL extension can use them. They're useful if you want a non-asynchronous version, but the matching names makes them awkward to use in an asynchronous context as

```swift
func parseChunks(url: URL) async throws {
    let chunkStream = urlsession.chunks(for:url)
    for try await chunk in chunkStream {
    }
}
```

will cause a compiler error as it thinks the code should be using the async version of `chunks(for:delegate:)`

I'm not sure if they should be public, but with a different name to indicate their synchronous nature more.